### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/grading.yml
+++ b/.github/workflows/grading.yml
@@ -1,4 +1,6 @@
 name: Grading workflow
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Trenzalore0/exercise-configure-codeql-language-matrix/security/code-scanning/4](https://github.com/Trenzalore0/exercise-configure-codeql-language-matrix/security/code-scanning/4)

To fix this issue, we need to explicitly declare a `permissions` block in the workflow to restrict the default permissions granted to the GITHUB_TOKEN. The permissions block can be added either at the root of the workflow (after `name` but before `jobs`) to affect all jobs, or individually for each job. Since the principle of least privilege applies, and based on the workflow content, it is likely that read access to contents and possibly write access to pull requests is sufficient; as a minimal starting point, GitHub recommends `contents: read`. If `looking-glass-action` requires broader permissions (for feedback comments, etc.), `pull-requests: write` could be added. For now, adding the following block immediately after the `name` line suffices:

```yaml
permissions:
  contents: read
```

This will limit repository contents permissions for all jobs. If later we discover jobs that require more than this, we could further specify at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
