### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,6 +4,8 @@ on: push
 
 jobs:
   markdown-link-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.repository == 'githubtraining/exercise-configure-codeql-language-matrix'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Trenzalore0/exercise-configure-codeql-language-matrix/security/code-scanning/2](https://github.com/Trenzalore0/exercise-configure-codeql-language-matrix/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block to limit the default GITHUB_TOKEN permissions for the job. Since the workflow checks out the repository and performs read-only validation via a link checker, it is sufficient to provide only `contents: read` permission. This change should be made by adding `permissions: contents: read` to either the workflow root (to apply to all jobs) or, preferably, underneath the specific job definition (`markdown-link-check`) to make the scope of the permissions clear and minimal. No changes to other jobs or steps are necessary; only the permissions block needs to be added in the job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
