### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,6 @@
 name: CI for local-action
+permissions:
+  contents: read
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Trenzalore0/exercise-configure-codeql-language-matrix/security/code-scanning/1](https://github.com/Trenzalore0/exercise-configure-codeql-language-matrix/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow file at the top level, such that all jobs inherit the minimal required permissions. Since this workflow only checks out repository code and runs tests, it should suffice to grant only `contents: read`. Place this block directly after the `name:` (line 1) and before `on:` (line 2), or after `on:` and before `jobs:` (line 6 or 7), following best practices for YAML readability. No further modifications are required elsewhere in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
